### PR TITLE
Feature: Configurable file save interval for ACS

### DIFF
--- a/inlinino/gui.py
+++ b/inlinino/gui.py
@@ -13,6 +13,7 @@ import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, uic
 from PyQt5 import QtMultimedia
+from PyQt5.QtCore import QLocale
 from pyACS.acs import ACS as ACSParser
 import pySatlantic.instrument as pySat
 
@@ -1469,6 +1470,8 @@ class DialogLoggerOptions(QtGui.QDialog):
 class App(QtGui.QApplication):
     def __init__(self, *args):
         QtGui.QApplication.__init__(self, *args)
+        # Set locale (important for decimal-separators)
+        QLocale.setDefault(QLocale(QLocale.English, QLocale.UnitedStates))
         self.splash_screen = QtGui.QSplashScreen(QtGui.QPixmap(os.path.join(PATH_TO_RESOURCES, 'inlinino.ico')))
         self.splash_screen.show()
         self.setWindowIcon(QtGui.QIcon(os.path.join(PATH_TO_RESOURCES, 'inlinino.ico')))

--- a/inlinino/resources/setup_acs.ui
+++ b/inlinino/resources/setup_acs.ui
@@ -97,31 +97,40 @@
       </layout>
      </item>
      <item row="2" column="0">
-        <widget class="QLabel" name="label_log_period">
-        <property name="text">
-        <string>File save interval (minutes)</string>
-        </property>
-        </widget>
-    </item>
+      <widget class="QLabel" name="label_log_period">
+       <property name="text">
+        <string>File Rotation (min)</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1">
-        <widget class="QDoubleSpinBox" name="le_length">
-        <property name="decimals">
-            <number>1</number>
-        </property>
-        <property name="maximum">
-            <double>86400.0</double>
-        </property>
-        <property name="minimum">
-            <double>0.01</double>
-        </property>
-        <property name="singleStep">
-            <double>1.0</double>
-        </property>
-        <property name="value">
-            <double>60.0</double>
-        </property>
-        </widget>
-    </item>
+      <widget class="QDoubleSpinBox" name="sb_length">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>File rotation interval in minutes, correspond to the length of files recorded. A new file is created beyond that time. Default is 60 minutes.</string>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>525600.0</double>
+       </property>
+       <property name="singleStep">
+        <double>1.0</double>
+       </property>
+       <property name="value">
+        <double>60.0</double>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/inlinino/resources/setup_acs.ui
+++ b/inlinino/resources/setup_acs.ui
@@ -96,6 +96,32 @@
        </item>
       </layout>
      </item>
+     <item row="2" column="0">
+        <widget class="QLabel" name="label_log_period">
+        <property name="text">
+        <string>File save interval (minutes)</string>
+        </property>
+        </widget>
+    </item>
+     <item row="2" column="1">
+        <widget class="QDoubleSpinBox" name="le_length">
+        <property name="decimals">
+            <number>1</number>
+        </property>
+        <property name="maximum">
+            <double>86400.0</double>
+        </property>
+        <property name="minimum">
+            <double>0.01</double>
+        </property>
+        <property name="singleStep">
+            <double>1.0</double>
+        </property>
+        <property name="value">
+            <double>60.0</double>
+        </property>
+        </widget>
+    </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
When using the ACS instrument you can now configure the interval after which a new file is saved (cf. #14).

Furthermore, this fixes a bug where e.g. locales with decimal separators that are not "." can break the floating point parsing logic. 